### PR TITLE
環境構築の微修正

### DIFF
--- a/backend/snack-review-rails/Gemfile.lock
+++ b/backend/snack-review-rails/Gemfile.lock
@@ -109,6 +109,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.14.0-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.14.0-x86_64-darwin)
+      racc (~> 1.4)
     puma (5.6.5)
       nio4r (~> 2.0)
     racc (1.6.2)
@@ -155,6 +157,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  x86_64-darwin-22
 
 DEPENDENCIES
   bootsnap

--- a/backend/snack-review-rails/config/puma.rb
+++ b/backend/snack-review-rails/config/puma.rb
@@ -15,7 +15,7 @@ worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port ENV.fetch("PORT") { 3000 }
+port ENV.fetch("PORT") { 3001 }
 
 # Specifies the `environment` that Puma will run in.
 #


### PR DESCRIPTION
## やったこと

- Gemfile.lockの更新(環境による差分)
- 起動のポートを3001番に変更

## やらないこと

- なし

## できるようになること（ユーザ目線）

- Next.jsとRailsのポートが被らずに同時に起動できる

## できなくなること（ユーザ目線）

- なし

## 動作確認

- rails sでRailsを起動してlocalhost:3001でRailsの初期画面が表示されることを確認

## その他

- なし
