### PR TITLE
[Create]table-articles,categories,shops,[Add]gem-annotate

### DIFF
--- a/backend/snack-review-rails/Gemfile
+++ b/backend/snack-review-rails/Gemfile
@@ -44,5 +44,6 @@ end
 group :development do
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem "spring"
+  gem "annotate"
 end
 

--- a/backend/snack-review-rails/Gemfile.lock
+++ b/backend/snack-review-rails/Gemfile.lock
@@ -66,6 +66,9 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
+    annotate (3.2.0)
+      activerecord (>= 3.2, < 8.0)
+      rake (>= 10.4, < 14.0)
     bootsnap (1.15.0)
       msgpack (~> 1.2)
     builder (3.2.4)
@@ -157,9 +160,11 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  x86_64-darwin-21
   x86_64-darwin-22
 
 DEPENDENCIES
+  annotate
   bootsnap
   debug
   mysql2 (~> 0.5)

--- a/backend/snack-review-rails/app/models/article.rb
+++ b/backend/snack-review-rails/app/models/article.rb
@@ -1,0 +1,17 @@
+# == Schema Information
+#
+# Table name: articles
+#
+#  id           :bigint           not null, primary key
+#  content      :text(65535)
+#  discarded_at :datetime
+#  title        :string(255)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+class Article < ApplicationRecord
+  validates :title, presence: true
+  validates :content, presence: true
+  belongs_to :shop
+  belongs_to :category
+end

--- a/backend/snack-review-rails/app/models/category.rb
+++ b/backend/snack-review-rails/app/models/category.rb
@@ -1,0 +1,13 @@
+# == Schema Information
+#
+# Table name: categories
+#
+#  id         :bigint           not null, primary key
+#  name       :string(255)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+class Category < ApplicationRecord
+  validates :name, presence: true
+  has_many :articles
+end

--- a/backend/snack-review-rails/app/models/shop.rb
+++ b/backend/snack-review-rails/app/models/shop.rb
@@ -1,0 +1,13 @@
+# == Schema Information
+#
+# Table name: shops
+#
+#  id          :bigint           not null, primary key
+#  information :text(65535)
+#  url         :text(65535)
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+class Shop < ApplicationRecord
+  has_many :articles
+end

--- a/backend/snack-review-rails/db/migrate/20230118132324_create_articles.rb
+++ b/backend/snack-review-rails/db/migrate/20230118132324_create_articles.rb
@@ -1,0 +1,10 @@
+class CreateArticles < ActiveRecord::Migration[7.0]
+  def change
+    create_table :articles do |t|
+      t.string :title
+      t.text :content
+
+      t.timestamps
+    end
+  end
+end

--- a/backend/snack-review-rails/db/migrate/20230118142409_create_categories.rb
+++ b/backend/snack-review-rails/db/migrate/20230118142409_create_categories.rb
@@ -1,0 +1,10 @@
+class CreateCategories < ActiveRecord::Migration[7.0]
+  def change
+    create_table :categories do |t|
+      t.string :name
+      t.string :string
+
+      t.timestamps
+    end
+  end
+end

--- a/backend/snack-review-rails/db/migrate/20230118155735_create_shops.rb
+++ b/backend/snack-review-rails/db/migrate/20230118155735_create_shops.rb
@@ -1,0 +1,10 @@
+class CreateShops < ActiveRecord::Migration[7.0]
+  def change
+    create_table :shops do |t|
+      t.text :information
+      t.text :url
+
+      t.timestamps
+    end
+  end
+end

--- a/backend/snack-review-rails/db/migrate/20230118162047_add_column_articles.rb
+++ b/backend/snack-review-rails/db/migrate/20230118162047_add_column_articles.rb
@@ -1,0 +1,5 @@
+class AddColumnArticles < ActiveRecord::Migration[7.0]
+  def change
+    add_column :articles, :discarded_at, :datetime
+  end
+end

--- a/backend/snack-review-rails/db/migrate/20230118213858_remove_column_categories.rb
+++ b/backend/snack-review-rails/db/migrate/20230118213858_remove_column_categories.rb
@@ -1,0 +1,5 @@
+class RemoveColumnCategories < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :categories, :string, :string
+  end
+end

--- a/backend/snack-review-rails/db/schema.rb
+++ b/backend/snack-review-rails/db/schema.rb
@@ -1,0 +1,35 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.0].define(version: 2023_01_18_213858) do
+  create_table "articles", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "title"
+    t.text "content"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "discarded_at"
+  end
+
+  create_table "categories", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "shops", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.text "information"
+    t.text "url"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+end

--- a/backend/snack-review-rails/lib/tasks/auto_annotate_models.rake
+++ b/backend/snack-review-rails/lib/tasks/auto_annotate_models.rake
@@ -1,0 +1,59 @@
+# NOTE: only doing this in development as some production environments (Heroku)
+# NOTE: are sensitive to local FS writes, and besides -- it's just not proper
+# NOTE: to have a dev-mode tool do its thing in production.
+if Rails.env.development?
+  require 'annotate'
+  task :set_annotation_options do
+    # You can override any of these by setting an environment variable of the
+    # same name.
+    Annotate.set_defaults(
+      'active_admin'                => 'false',
+      'additional_file_patterns'    => [],
+      'routes'                      => 'false',
+      'models'                      => 'true',
+      'position_in_routes'          => 'before',
+      'position_in_class'           => 'before',
+      'position_in_test'            => 'before',
+      'position_in_fixture'         => 'before',
+      'position_in_factory'         => 'before',
+      'position_in_serializer'      => 'before',
+      'show_foreign_keys'           => 'true',
+      'show_complete_foreign_keys'  => 'false',
+      'show_indexes'                => 'true',
+      'simple_indexes'              => 'false',
+      'model_dir'                   => 'app/models',
+      'root_dir'                    => '',
+      'include_version'             => 'false',
+      'require'                     => '',
+      'exclude_tests'               => 'false',
+      'exclude_fixtures'            => 'false',
+      'exclude_factories'           => 'false',
+      'exclude_serializers'         => 'false',
+      'exclude_scaffolds'           => 'true',
+      'exclude_controllers'         => 'true',
+      'exclude_helpers'             => 'true',
+      'exclude_sti_subclasses'      => 'false',
+      'ignore_model_sub_dir'        => 'false',
+      'ignore_columns'              => nil,
+      'ignore_routes'               => nil,
+      'ignore_unknown_models'       => 'false',
+      'hide_limit_column_types'     => 'integer,bigint,boolean',
+      'hide_default_column_types'   => 'json,jsonb,hstore',
+      'skip_on_db_migrate'          => 'false',
+      'format_bare'                 => 'true',
+      'format_rdoc'                 => 'false',
+      'format_yard'                 => 'false',
+      'format_markdown'             => 'false',
+      'sort'                        => 'false',
+      'force'                       => 'false',
+      'frozen'                      => 'false',
+      'classified_sort'             => 'true',
+      'trace'                       => 'false',
+      'wrapper_open'                => nil,
+      'wrapper_close'               => nil,
+      'with_comment'                => 'true'
+    )
+  end
+
+  Annotate.load_tasks
+end

--- a/backend/snack-review-rails/test/fixtures/articles.yml
+++ b/backend/snack-review-rails/test/fixtures/articles.yml
@@ -1,0 +1,19 @@
+# == Schema Information
+#
+# Table name: articles
+#
+#  id           :bigint           not null, primary key
+#  content      :text(65535)
+#  discarded_at :datetime
+#  title        :string(255)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+
+one:
+  title: MyString
+  content: MyText
+
+two:
+  title: MyString
+  content: MyText

--- a/backend/snack-review-rails/test/fixtures/categories.yml
+++ b/backend/snack-review-rails/test/fixtures/categories.yml
@@ -1,0 +1,17 @@
+# == Schema Information
+#
+# Table name: categories
+#
+#  id         :bigint           not null, primary key
+#  name       :string(255)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+one:
+  name: MyString
+  string: MyString
+
+two:
+  name: MyString
+  string: MyString

--- a/backend/snack-review-rails/test/fixtures/shops.yml
+++ b/backend/snack-review-rails/test/fixtures/shops.yml
@@ -1,0 +1,18 @@
+# == Schema Information
+#
+# Table name: shops
+#
+#  id          :bigint           not null, primary key
+#  information :text(65535)
+#  url         :text(65535)
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+
+one:
+  information: MyText
+  url: MyText
+
+two:
+  information: MyText
+  url: MyText

--- a/backend/snack-review-rails/test/models/article_test.rb
+++ b/backend/snack-review-rails/test/models/article_test.rb
@@ -1,0 +1,18 @@
+# == Schema Information
+#
+# Table name: articles
+#
+#  id           :bigint           not null, primary key
+#  content      :text(65535)
+#  discarded_at :datetime
+#  title        :string(255)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+require "test_helper"
+
+class ArticleTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/backend/snack-review-rails/test/models/category_test.rb
+++ b/backend/snack-review-rails/test/models/category_test.rb
@@ -1,0 +1,16 @@
+# == Schema Information
+#
+# Table name: categories
+#
+#  id         :bigint           not null, primary key
+#  name       :string(255)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+require "test_helper"
+
+class CategoryTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/backend/snack-review-rails/test/models/shop_test.rb
+++ b/backend/snack-review-rails/test/models/shop_test.rb
@@ -1,0 +1,17 @@
+# == Schema Information
+#
+# Table name: shops
+#
+#  id          :bigint           not null, primary key
+#  information :text(65535)
+#  url         :text(65535)
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+require "test_helper"
+
+class ShopTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## やったこと

- gem “annotate”のによるschemaをモデルへ表示
- モデル・テーブル・カラムの作成(Article、Shop、Category）
- 論理削除用のカラムdiscarded_atは追加済み -モデル間のリレーション記載
- 空白に対するバリデーション

## やらないこと
-usersテーブルの作成（あるどんさん作成のdeviseによるusersを使用予定）
- 文字数制限のバリデーション（フェーズ2で検討してから）

## できるようになること（ユーザ目線）
- 無し

## できなくなること（ユーザ目線）
- 無し

## 動作確認
- 行っていません

## その他
- 無し
