### PR TITLE
[Add]NOT NULL for users-column-name

### DIFF
--- a/backend/snack-review-rails/app/models/user.rb
+++ b/backend/snack-review-rails/app/models/user.rb
@@ -11,7 +11,7 @@
 #  encrypted_password :string(255)      default(""), not null
 #  last_sign_in_at    :datetime
 #  last_sign_in_ip    :string(255)
-#  name               :string(255)
+#  name               :string(255)      not null
 #  provider           :string(255)      default("email"), not null
 #  sign_in_count      :integer          default(0), not null
 #  tokens             :text(65535)

--- a/backend/snack-review-rails/db/migrate/20230211133020_change_column_null_on_users.rb
+++ b/backend/snack-review-rails/db/migrate/20230211133020_change_column_null_on_users.rb
@@ -1,0 +1,5 @@
+class ChangeColumnNullOnUsers < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :users, :name, false
+  end
+end

--- a/backend/snack-review-rails/db/schema.rb
+++ b/backend/snack-review-rails/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_06_225331) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_11_133020) do
   create_table "articles", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "title", null: false
     t.text "content", null: false
@@ -38,7 +38,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_06_225331) do
     t.string "provider", default: "email", null: false
     t.string "uid", default: "", null: false
     t.string "encrypted_password", default: "", null: false
-    t.string "name"
+    t.string "name", null: false
     t.string "email"
     t.text "tokens"
     t.integer "sign_in_count", default: 0, null: false


### PR DESCRIPTION
## やったこと

-usersテーブルのnameカラムにNOT NULL制約を追加

## やらないこと

## できるようになること（ユーザ目線）

## できなくなること（ユーザ目線）

- 特になし

## 動作確認

schemaファイルにて
`t.string "name", null: false`
を確認しました。
<img width="819" alt="スクリーンショット 2023-02-11 22 32 09" src="https://user-images.githubusercontent.com/86139603/218262252-899682f0-44ec-48ac-9164-c526e14f6217.png">

## その他
migrationファイル変更しています。
rails db:migrateを実行してschemaの変更をお願いします。

