### PR TITLE
Be/signup name field

### DIFF
--- a/backend/snack-review-rails/Gemfile
+++ b/backend/snack-review-rails/Gemfile
@@ -41,7 +41,7 @@ group :development, :test do
   gem "debug", platforms: %i[ mri mingw x64_mingw ]
   gem "factory_bot_rails"
   gem "rspec-rails"
-  gem "pry-rails"
+  gem "pry-byebug"
 end
 
 group :development do

--- a/backend/snack-review-rails/Gemfile.lock
+++ b/backend/snack-review-rails/Gemfile.lock
@@ -89,6 +89,7 @@ GEM
     bootsnap (1.16.0)
       msgpack (~> 1.2)
     builder (3.2.4)
+    byebug (11.1.3)
     case_transform (0.2)
       activesupport
     choice (0.2.0)
@@ -224,8 +225,9 @@ GEM
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    pry-rails (0.3.9)
-      pry (>= 0.10.4)
+    pry-byebug (3.10.1)
+      byebug (~> 11.0)
+      pry (>= 0.13, < 0.15)
     puma (5.6.5)
       nio4r (~> 2.0)
     racc (1.6.2)
@@ -338,7 +340,7 @@ DEPENDENCIES
   kaminari
   mysql2 (~> 0.5)
   open_graph_reader
-  pry-rails
+  pry-byebug
   puma (~> 5.0)
   rack-cors
   rails (~> 7.0.4)

--- a/backend/snack-review-rails/app/controllers/api/v1/registrations_controller.rb
+++ b/backend/snack-review-rails/app/controllers/api/v1/registrations_controller.rb
@@ -1,0 +1,22 @@
+class Api::V1::RegistrationsController < DeviseTokenAuth::RegistrationsController
+  respond_to :json
+  def create
+    #build_resource
+    #@resource['name']=params['name']
+    #@resource.save
+    binding.pry
+    #render_create_success
+
+    super 
+  end 
+
+  private
+  def sign_up_params
+    params.require(:registration).permit(:name,:email, :password, :password_confirmation)
+  end
+
+  def account_update_params
+    params.require(:registration).permit(:name,:email, :password, :password_confirmation)
+ end
+end
+

--- a/backend/snack-review-rails/app/controllers/api/v1/registrations_controller.rb
+++ b/backend/snack-review-rails/app/controllers/api/v1/registrations_controller.rb
@@ -7,7 +7,7 @@ class Api::V1::RegistrationsController < DeviseTokenAuth::RegistrationsControlle
   end
 
   def account_update_params
-    params.require(:registration).permit(:name, :email, :password, :password_confirmation)
+    params.require(:registration).ermit(:name, :email, :password, :password_confirmation)
  end
 end
 

--- a/backend/snack-review-rails/app/controllers/api/v1/registrations_controller.rb
+++ b/backend/snack-review-rails/app/controllers/api/v1/registrations_controller.rb
@@ -1,22 +1,13 @@
 class Api::V1::RegistrationsController < DeviseTokenAuth::RegistrationsController
   respond_to :json
-  def create
-    #build_resource
-    #@resource['name']=params['name']
-    #@resource.save
-    binding.pry
-    #render_create_success
-
-    super 
-  end 
 
   private
   def sign_up_params
-    params.require(:registration).permit(:name,:email, :password, :password_confirmation)
+    params.require(:registration).permit(:name, :email, :password, :password_confirmation)
   end
 
   def account_update_params
-    params.require(:registration).permit(:name,:email, :password, :password_confirmation)
+    params.require(:registration).permit(:name, :email, :password, :password_confirmation)
  end
 end
 

--- a/backend/snack-review-rails/app/controllers/v1/auth/registrations_controller.rb
+++ b/backend/snack-review-rails/app/controllers/v1/auth/registrations_controller.rb
@@ -1,2 +1,0 @@
-class V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsController
-end

--- a/backend/snack-review-rails/app/models/user.rb
+++ b/backend/snack-review-rails/app/models/user.rb
@@ -44,5 +44,4 @@ class User < ActiveRecord::Base
   include DeviseTokenAuth::Concerns::User
 
   has_many :articles
-  attr_accessor :name
 end

--- a/backend/snack-review-rails/config/routes.rb
+++ b/backend/snack-review-rails/config/routes.rb
@@ -5,7 +5,10 @@ Rails.application.routes.draw do
 
   namespace 'api' do
     namespace 'v1' do 
-      mount_devise_token_auth_for "User", at: "auth"
+      mount_devise_token_auth_for "User", at: "auth",
+      controllers: {
+        registrations: 'api/v1/registrations'
+      }
       resources :articles, except: [:new, :edit]
       resources :categories, only: [:index]
     end


### PR DESCRIPTION
## やったこと
- gem pry-byebug の追加
- サインアップ時にnameが登録できないことの解消

## やらないこと

- ユーザー情報のアップデート処理についてはテストが必要

## 動作確認

curl コマンドとDBの状態を確認
実行コマンド
```
curl localhost:3001/api/v1/auth -X POST  -d '{"name":"888","email":"558124d9fz5z@exakkkkkmkplek.com", "pass
word":"password", "password_confirmation": "password"}' -H "content-type:application/json"
```

発行SQL
```
 INSERT INTO `users` (`provider`, `uid`, `encrypted_password`, `name`, `email`, `tokens`, `sign_in_count`, `current_sign_in_at`, `last_sign_in_at`, `current_sign_in_ip`, `last_sign_in_ip`, `created_at`, `updated_at`) VALUES ('email', '558124d9fz5z@exakkkkkmkplek.com', '$2a$12$ZSNbM5YrT3T1cESpuKAttuhJsPXQ8TjS0e/PqcJLY06DkwPkCpI3a', '888', '558124d9fz5z@exakkkkkmkplek.com', NULL, 0, NULL, NULL, NULL, NULL, '2023-02-16 18:12:28.007399', '2023-02-16 18:12:28.007399')
  TRANSACTION (3.1ms)  COMMIT
```

## その他

`bundle install` が必要です。

-
