### PR TITLE
[Add]sample-seed/users

### DIFF
--- a/backend/snack-review-rails/Gemfile
+++ b/backend/snack-review-rails/Gemfile
@@ -50,6 +50,7 @@ group :development do
   gem "annotate"
   gem "rubocop" 
   gem "rails-erd" 
+  gem 'faker'
 end
 
 gem "kaminari" 

--- a/backend/snack-review-rails/Gemfile.lock
+++ b/backend/snack-review-rails/Gemfile.lock
@@ -158,6 +158,8 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
+    faker (3.1.1)
+      i18n (>= 1.8.11, < 2)
     faraday (2.7.4)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
@@ -212,6 +214,8 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.8)
+    nokogiri (1.14.2-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.14.2-x86_64-linux)
       racc (~> 1.4)
     open_graph_reader (0.7.2)
@@ -320,6 +324,7 @@ GEM
     zeitwerk (2.6.7)
 
 PLATFORMS
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES
@@ -333,6 +338,7 @@ DEPENDENCIES
   discard
   dotenv-rails
   factory_bot_rails
+  faker
   impressionist!
   jbuilder
   kaminari

--- a/backend/snack-review-rails/app/models/user.rb
+++ b/backend/snack-review-rails/app/models/user.rb
@@ -4,37 +4,25 @@
 #
 # Table name: users
 #
-#  id                     :bigint           not null, primary key
-#  allow_password_change  :boolean          default(FALSE)
-#  confirmation_sent_at   :datetime
-#  confirmation_token     :string(255)
-#  confirmed_at           :datetime
-#  current_sign_in_at     :datetime
-#  current_sign_in_ip     :string(255)
-#  email                  :string(255)
-#  encrypted_password     :string(255)      default(""), not null
-#  image                  :string(255)
-#  last_sign_in_at        :datetime
-#  last_sign_in_ip        :string(255)
-#  name                   :string(255)
-#  nickname               :string(255)
-#  provider               :string(255)      default("email"), not null
-#  remember_created_at    :datetime
-#  reset_password_sent_at :datetime
-#  reset_password_token   :string(255)
-#  sign_in_count          :integer          default(0), not null
-#  tokens                 :text(65535)
-#  uid                    :string(255)      default(""), not null
-#  unconfirmed_email      :string(255)
-#  created_at             :datetime         not null
-#  updated_at             :datetime         not null
+#  id                 :bigint           not null, primary key
+#  current_sign_in_at :datetime
+#  current_sign_in_ip :string(255)
+#  email              :string(255)
+#  encrypted_password :string(255)      default(""), not null
+#  last_sign_in_at    :datetime
+#  last_sign_in_ip    :string(255)
+#  name               :string(255)
+#  provider           :string(255)      default("email"), not null
+#  sign_in_count      :integer          default(0), not null
+#  tokens             :text(65535)
+#  uid                :string(255)      default(""), not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
 #
 # Indexes
 #
-#  index_users_on_confirmation_token    (confirmation_token) UNIQUE
-#  index_users_on_email                 (email) UNIQUE
-#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
-#  index_users_on_uid_and_provider      (uid,provider) UNIQUE
+#  index_users_on_email             (email) UNIQUE
+#  index_users_on_uid_and_provider  (uid,provider) UNIQUE
 #
 class User < ActiveRecord::Base
   # Include default devise modules. Others available are:
@@ -44,5 +32,5 @@ class User < ActiveRecord::Base
   include DeviseTokenAuth::Concerns::User
 
   has_many :articles
-  attr_accessor :name
+  # attr_accessor :name
 end

--- a/backend/snack-review-rails/db/schema.rb
+++ b/backend/snack-review-rails/db/schema.rb
@@ -11,7 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[7.0].define(version: 2023_02_11_133020) do
-  create_table "articles", charset: "utf8mb4", force: :cascade do |t|
+  create_table "articles", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "title", null: false
     t.text "content", null: false
     t.datetime "created_at", null: false
@@ -28,7 +28,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_11_133020) do
     t.index ["user_id"], name: "index_articles_on_user_id"
   end
 
-  create_table "categories", charset: "utf8mb4", force: :cascade do |t|
+  create_table "categories", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "category_name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -38,7 +38,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_11_133020) do
     t.index ["discarded_at"], name: "index_categories_on_discarded_at"
   end
 
-  create_table "impressions", charset: "utf8mb4", force: :cascade do |t|
+  create_table "impressions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "impressionable_type"
     t.integer "impressionable_id"
     t.integer "user_id"
@@ -64,21 +64,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_11_133020) do
     t.index ["user_id"], name: "index_impressions_on_user_id"
   end
 
-  create_table "users", charset: "utf8mb4", force: :cascade do |t|
+  create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "provider", default: "email", null: false
     t.string "uid", default: "", null: false
     t.string "encrypted_password", default: "", null: false
-    t.string "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.boolean "allow_password_change", default: false
-    t.datetime "remember_created_at"
-    t.string "confirmation_token"
-    t.datetime "confirmed_at"
-    t.datetime "confirmation_sent_at"
-    t.string "unconfirmed_email"
     t.string "name"
-    t.string "nickname"
-    t.string "image"
     t.string "email"
     t.text "tokens"
     t.integer "sign_in_count", default: 0, null: false
@@ -88,9 +78,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_11_133020) do
     t.string "last_sign_in_ip"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 

--- a/backend/snack-review-rails/db/seeds.rb
+++ b/backend/snack-review-rails/db/seeds.rb
@@ -6,13 +6,9 @@
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
 
-Category.create(
-  [
-    { category_name: '焼き菓子', category_color: 'bg-red-400' },
-    { category_name: 'ケーキ', category_color: 'bg-blue-400' },
-    { category_name: 'チョコ', category_color: 'bg-green-400' },
-    { category_name: '和菓子', category_color: 'bg-purple-400' },
-    { category_name: 'その他', category_color: 'bg-yellow-400' }
-  ]
-)
+
+
+
+require './db/seeds/categories'
+require './db/seeds/users'
 

--- a/backend/snack-review-rails/db/seeds/categories.rb
+++ b/backend/snack-review-rails/db/seeds/categories.rb
@@ -1,0 +1,9 @@
+Category.create(
+  [
+    { category_name: '焼き菓子', category_color: 'bg-red-400' },
+    { category_name: 'ケーキ', category_color: 'bg-blue-400' },
+    { category_name: 'チョコ', category_color: 'bg-green-400' },
+    { category_name: '和菓子', category_color: 'bg-purple-400' },
+    { category_name: 'その他', category_color: 'bg-yellow-400' }
+  ]
+)

--- a/backend/snack-review-rails/db/seeds/users.rb
+++ b/backend/snack-review-rails/db/seeds/users.rb
@@ -1,0 +1,9 @@
+# usersのテスト用ダミーファイル
+20.times do
+  User.create!(
+     name: Faker::JapaneseMedia::DragonBall.unique.character,
+     email: Faker::Internet.email,
+     password: "1234test",
+     password_confirmation: "1234test"
+   )
+end

--- a/backend/snack-review-rails/spec/factories/user_factory.rb
+++ b/backend/snack-review-rails/spec/factories/user_factory.rb
@@ -2,37 +2,25 @@
 #
 # Table name: users
 #
-#  id                     :bigint           not null, primary key
-#  allow_password_change  :boolean          default(FALSE)
-#  confirmation_sent_at   :datetime
-#  confirmation_token     :string(255)
-#  confirmed_at           :datetime
-#  current_sign_in_at     :datetime
-#  current_sign_in_ip     :string(255)
-#  email                  :string(255)
-#  encrypted_password     :string(255)      default(""), not null
-#  image                  :string(255)
-#  last_sign_in_at        :datetime
-#  last_sign_in_ip        :string(255)
-#  name                   :string(255)
-#  nickname               :string(255)
-#  provider               :string(255)      default("email"), not null
-#  remember_created_at    :datetime
-#  reset_password_sent_at :datetime
-#  reset_password_token   :string(255)
-#  sign_in_count          :integer          default(0), not null
-#  tokens                 :text(65535)
-#  uid                    :string(255)      default(""), not null
-#  unconfirmed_email      :string(255)
-#  created_at             :datetime         not null
-#  updated_at             :datetime         not null
+#  id                 :bigint           not null, primary key
+#  current_sign_in_at :datetime
+#  current_sign_in_ip :string(255)
+#  email              :string(255)
+#  encrypted_password :string(255)      default(""), not null
+#  last_sign_in_at    :datetime
+#  last_sign_in_ip    :string(255)
+#  name               :string(255)
+#  provider           :string(255)      default("email"), not null
+#  sign_in_count      :integer          default(0), not null
+#  tokens             :text(65535)
+#  uid                :string(255)      default(""), not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
 #
 # Indexes
 #
-#  index_users_on_confirmation_token    (confirmation_token) UNIQUE
-#  index_users_on_email                 (email) UNIQUE
-#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
-#  index_users_on_uid_and_provider      (uid,provider) UNIQUE
+#  index_users_on_email             (email) UNIQUE
+#  index_users_on_uid_and_provider  (uid,provider) UNIQUE
 #
 FactoryBot.define do
   factory :user do


### PR DESCRIPTION
## やったこと

- seeds.rbと同一階層にseedファイルを作成
- さらにそのseedファイルの中にcategories.rb、users.rbを作成しそれぞれのsampleデータを記述
- seeds.rb内にはそれぞれのファイルを読み込むための記述を行いました
- usersについては gem 'faker'を使用して以下カラムのsampleデータを作成
name、email、password、password_confirmation

## やらないこと

- categoriesのseedファイルの内容は今回のプルリクでは変更していません。
- 別途プルリクを行う予定です。

## できるようになること（ユーザ目線）

- 20件のsampleデータをフロントに渡すことができる

## できなくなること（ユーザ目線）

- なし

## 動作確認

- rails c　にてコンソールに以下が表示されることを確認しました。
<img width="1440" alt="スクリーンショット 2023-02-17 14 23 11" src="https://user-images.githubusercontent.com/86139603/219578937-9b585ba9-f84f-44b2-a13a-42c6eed0f686.png">


## その他

- gemを追加しています
bundle installしてください
- seed　ファイルを変更しています
rails db:migrate:reset → rails db:seed　にてデータベースをリセットして反映お願いします。
