### PR TITLE
be/fix-cors

### DIFF
--- a/backend/snack-review-rails/config/application.rb
+++ b/backend/snack-review-rails/config/application.rb
@@ -30,7 +30,7 @@ module SnackReviewRails
     config.middleware.use ActionDispatch::Flash
     config.middleware.insert_before 0, Rack::Cors do
       allow do
-        origins '*'
+        origins ENV.fetch("FRONT_URL")
         resource '*',
                  :headers => :any,
                  :expose => ['access-token', 'expiry', 'token-type', 'uid', 'client'],

--- a/backend/snack-review-rails/config/initializers/cors.rb
+++ b/backend/snack-review-rails/config/initializers/cors.rb
@@ -12,6 +12,7 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
     resource "*",
       headers: :any,
       expose: ['access-token', 'expiry', 'token-type', 'uid', 'client'],
-      methods: [:get, :post, :put, :patch, :delete, :options, :head]
+      methods: [:get, :post, :put, :patch, :delete, :options, :head],
+      credentials: true
   end
 end


### PR DESCRIPTION
## やったこと

CORS対応

 origins ENV.fetch("FRONT_URL")の追加
## 動作確認


リクエストヘッダ
originが正しく設定されている
![image](https://user-images.githubusercontent.com/82225965/219584271-11e8a88b-7547-4cfe-8e41-31d21a9f2106.png)

レスポンスヘッダ
Access-Control-Allow-Originが正しく設定されている。（.envのFRONT_URLが反映される。）
![image](https://user-images.githubusercontent.com/82225965/219584568-8e16686e-947b-4ffd-a525-78cd96daac32.png)

-

## その他


