### PR TITLE
[Add]seed/samples

### DIFF
--- a/backend/snack-review-rails/config/application.rb
+++ b/backend/snack-review-rails/config/application.rb
@@ -11,6 +11,10 @@ module SnackReviewRails
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0
 
+    # fakerを日本語化
+    Rails.application.config.i18n.default_locale = :ja
+    Faker::Config.locale = :ja
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/backend/snack-review-rails/db/seeds.rb
+++ b/backend/snack-review-rails/db/seeds.rb
@@ -6,9 +6,6 @@
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
 
-
-
-
 require './db/seeds/categories'
-require './db/seeds/users'
+require './db/seeds/samples'
 

--- a/backend/snack-review-rails/db/seeds/samples.rb
+++ b/backend/snack-review-rails/db/seeds/samples.rb
@@ -12,11 +12,11 @@ end
 # articlesのテスト用ダミーファイル
 9.times do 
   Article.create!(
-    title: Faker::Books::CultureSeries.unique.book,
-    content: Faker::JapaneseMedia::OnePiece.unique.quote,
-    category_id: Faker::Number.between(from: 1, to: 9),
+    title: Faker::Lorem.sentence,
+    content: Faker::Lorem.paragraphs,
+    category_id: Faker::Number.between(from: 1, to: 3),
     user_id: Faker::Number.between(from: 1, to: 20),
-    shops_information:Faker::Restaurant.review,
+    shops_information:Faker::Lorem.sentences,
     url: Faker::Internet.url,
     image_url: Faker::Avatar.image,
     impressions_count:Faker::Number.between(from: 1, to: 10)

--- a/backend/snack-review-rails/db/seeds/samples.rb
+++ b/backend/snack-review-rails/db/seeds/samples.rb
@@ -14,7 +14,7 @@ end
   Article.create!(
     title: Faker::Lorem.sentence,
     content: Faker::Lorem.paragraphs,
-    category_id: Faker::Number.between(from: 1, to: 3),
+    category_id: Faker::Number.between(from: 1, to: 9),
     user_id: Faker::Number.between(from: 1, to: 20),
     shops_information:Faker::Lorem.sentences,
     url: Faker::Internet.url,

--- a/backend/snack-review-rails/db/seeds/samples.rb
+++ b/backend/snack-review-rails/db/seeds/samples.rb
@@ -1,0 +1,25 @@
+# usersのテスト用ダミーファイル
+20.times do
+  User.create!(
+     name: Faker::JapaneseMedia::DragonBall.unique.character,
+     email: Faker::Internet.email,
+     password: "1234test",
+     password_confirmation: "1234test"
+   )
+end
+
+
+# articlesのテスト用ダミーファイル
+9.times do 
+  Article.create!(
+    title: Faker::Books::CultureSeries.unique.book,
+    content: Faker::JapaneseMedia::OnePiece.unique.quote,
+    category_id: Faker::Number.between(from: 1, to: 9),
+    user_id: Faker::Number.between(from: 1, to: 20),
+    shops_information:Faker::Restaurant.review,
+    url: Faker::Internet.url,
+    image_url: Faker::Avatar.image,
+    impressions_count:Faker::Number.between(from: 1, to: 10)
+  )
+end
+

--- a/backend/snack-review-rails/db/seeds/users.rb
+++ b/backend/snack-review-rails/db/seeds/users.rb
@@ -1,9 +1,0 @@
-# usersのテスト用ダミーファイル
-20.times do
-  User.create!(
-     name: Faker::JapaneseMedia::DragonBall.unique.character,
-     email: Faker::Internet.email,
-     password: "1234test",
-     password_confirmation: "1234test"
-   )
-end


### PR DESCRIPTION
## やったこと

- gem "faker"を使用してarticlesのsampleデータを作成しました。
- title、content、shop_informationについては日本語対応できるよう設定しています。
- seeds/users.rbをrenameしてseeds/samplesとし、その中でusers、articlesの両sampleを作成するよう変更しています。
- db/sees.rbでは実際に使用するseeds/categories.rbとテスト用にしか使用しないseeds/samplesに分けて読み込みを行なっています。

## やらないこと

- なし

## できるようになること（ユーザ目線）

- データベースの投稿テーブルに下記sampleデータを作成・保存、フロントエンドから呼び出すことができるようになる
title、content、category、user、shops_information、url、image_url（OGP代用としてアバター画像より引用）、impressions数

## できなくなること（ユーザ目線）

- なし

## 動作確認

- コンソール上にてarticlesデータが作成されることを確認しました。
- 一部データは日本語にて表記されることを確認しました
<img width="1334" alt="スクリーンショット 2023-02-19 5 34 04" src="https://user-images.githubusercontent.com/86139603/219897072-dfc1b1c1-da3d-48d8-994d-4fe26d474dfd.png">


## その他

- seedファイルを変更しているため
`rails db:migrate:reset`
`rails db:seed`
をおねがいします。

- categoriesのidを１〜９で設定しているため、categoriesのseedファイルが作成されていない状態で`rails db:seed`を行うとエラーとなるかもしれません。
先に[Add]seed/categories #61　にてアップしましたcategoriesのseedファイル設定を行うか、categoriesに９つ以上のsampleデータを作成してください。

遅くなり申し訳ありませんが、動作確認よろしくお願いします。