### PR TITLE
ログイン状態を取得する実装を追加

### DIFF
--- a/frontend/snack-review-next/src/app/layout.tsx
+++ b/frontend/snack-review-next/src/app/layout.tsx
@@ -1,8 +1,10 @@
 // eslint-disable-next-line camelcase
 import { M_PLUS_Rounded_1c } from "@next/font/google";
+import { cookies } from "next/headers";
 import type { ReactNode } from "react";
 import { Footer } from "@/component/template/footer/Footer";
 import "../styles/globals.css";
+import { validateUserToken } from "@/lib/getData";
 
 const mPlus = M_PLUS_Rounded_1c({
   subsets: ["japanese"],
@@ -10,8 +12,10 @@ const mPlus = M_PLUS_Rounded_1c({
   display: "swap",
 });
 
-const RootLayout = ({ children }: { children: ReactNode }) => {
-  const isLoggedIn = true;
+const RootLayout = async ({ children }: { children: ReactNode }) => {
+  const accessToken = cookies().get("access-token")?.value
+  const isLoggedIn = await validateUserToken(accessToken);
+
 
   return (
     <html lang="ja" data-theme="light">

--- a/frontend/snack-review-next/src/lib/authModule.ts
+++ b/frontend/snack-review-next/src/lib/authModule.ts
@@ -4,10 +4,23 @@ import { UserFormNameType } from "@/constants/InputField";
 import { axiosClient } from "@/lib/helpers";
 
 const setCookies = (res: AxiosResponse) => {
-  // FIXME: 有効期限をヘッダーの値から設定
-  Cookies.set("client", res.headers.client, { expires: 7 });
-  Cookies.set("access-token", res.headers["access-token"], { expires: 7 });
-  Cookies.set("uid", res.headers.uid, { expires: 7 });
+  const timestamp = res.headers.expiry;
+  const expires = Math.floor((timestamp - Date.now() / 1000) / 86400);
+
+  const AuthenticationHeaders = {
+    "access-token": res.headers["access-token"],
+    "token-type": res.headers["token-type"],
+    "client": res.headers.client,
+    "expiry": res.headers.expiry,
+    "uid": res.headers.uid
+  };
+
+  const token = btoa(JSON.stringify(AuthenticationHeaders));
+  const bearerToken = `Bearer ${token}`;
+
+  Cookies.set("client", res.headers.client, { expires });
+  Cookies.set("access-token", bearerToken, { expires });
+  Cookies.set("uid", res.headers.uid, { expires });
 };
 
 const clearCookies = () => {

--- a/frontend/snack-review-next/src/lib/getData.ts
+++ b/frontend/snack-review-next/src/lib/getData.ts
@@ -1,7 +1,7 @@
 import "server-only";
 
 import { articlesSchema, myProfileSchema, articleSchema } from "./zodSchema";
-import { GET_ARTICLES, GET_MY_PROFILE, getArticlePath } from "@/constants/endpoint";
+import { BASE_URL, GET_ARTICLES, GET_MY_PROFILE, getArticlePath } from "@/constants/endpoint";
 
 export const getUserData = async () => {
   const res = await fetch(GET_MY_PROFILE, { cache: "no-store" });
@@ -19,4 +19,15 @@ export const getArticle = async (id: string) => {
   const res = await fetch(getArticlePath(id), { cache: "no-store" });
   const data = await res.json();
   return articleSchema.parse(data);
+};
+
+export const validateUserToken = async (accessToken:string | undefined) => {
+  if (!accessToken) return false;
+  const res = await fetch(`${BASE_URL}/auth/validate_token`, {
+    cache: "no-store",
+    headers: {
+      "Authorization": `${accessToken}`,
+    }});
+  const data = await res.json();
+  return data.success;
 };


### PR DESCRIPTION
devise-token-authとフロントエンドを接続

## やったこと

<!-- このプルリクで何をしたのか？ -->

- ログイン状態をAPIから取得する実装を追加

## やらないこと

<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」で OK）（やらない場合は、いつやるのかを明記する。） -->

- 無し

## できるようになること（ユーザ目線）

<!-- 何ができるようになるのか？（あれば。無いなら「無し」で OK）-->

- ログイン後、ログイン状態を保持できる

## できなくなること（ユーザ目線）

<!-- 何ができるようになるのか？（あれば。無いなら「無し」で OK）-->

- 無し

## 動作確認

<!-- どのような動作確認を行ったのか？　結果はどうか？ -->

- ログイン後、validateUserTokenメソッドを使用し、APIから `success:true`の返答を確認

## その他

<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->

- 無し
