### PR TITLE
[WIP] Fe/user state

### DIFF
--- a/frontend/snack-review-next/.env.local.sample
+++ b/frontend/snack-review-next/.env.local.sample
@@ -1,0 +1,2 @@
+// ファイル名の.sampleを削除して使用してください
+NEXT_PUBLIC_BASE_URL="http://localhost:3001/api/v1";

--- a/frontend/snack-review-next/src/app/layout.tsx
+++ b/frontend/snack-review-next/src/app/layout.tsx
@@ -11,15 +11,13 @@ const mPlus = M_PLUS_Rounded_1c({
 });
 
 const RootLayout = ({ children }: { children: ReactNode }) => {
-  const isLoggedIn = true;
-
   return (
     <html lang="ja" data-theme="light">
       <head />
       <body className={`${mPlus.className} text-gray-700`}>
         <main>{children}</main>
         <div className="h-20" />
-        <Footer isLoggedIn={isLoggedIn} userName="シェアがしユーザーで名前の長いひと" />
+        <Footer />
       </body>
     </html>
   );

--- a/frontend/snack-review-next/src/app/loading.tsx
+++ b/frontend/snack-review-next/src/app/loading.tsx
@@ -1,9 +1,7 @@
+import { Loader } from "@/component/atoms/Loader";
+
 const Loading = () => {
-  return (
-    <div className="flex h-screen items-center justify-center">
-      <div className="h-10 w-10 animate-spin rounded-full border-4 border-red-400 border-t-transparent" />
-    </div>
-  );
+  return <Loader />;
 };
 
 export default Loading;

--- a/frontend/snack-review-next/src/app/my-profile/page.tsx
+++ b/frontend/snack-review-next/src/app/my-profile/page.tsx
@@ -1,19 +1,34 @@
+"use client";
+
+import Cookies from "js-cookie";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+import { Loader } from "@/component/atoms/Loader";
 import { CardList } from "@/component/template/home/CardList";
 import { MyProfileHeader } from "@/component/template/my-profile/MyProfileHeader";
 import { UserInfo } from "@/component/template/my-profile/UserInfo";
-import { getUserData } from "@/lib/getData";
+import { useUser } from "@/lib/useUser";
 
-const MyProfile = async () => {
-  const { articles } = await getUserData();
+const MyProfile = () => {
+  const router = useRouter();
+  const { data } = useUser();
+  const token = Cookies.get("access-token");
+
+  useEffect(() => {
+    if (!token) {
+      router.push("/");
+    }
+  }, [router, token]);
+
+  if (!data) return <Loader />;
 
   return (
     <div className="p-4">
       <div className="mb-20">
         <MyProfileHeader />
-        {/* @ts-expect-error Server Component */}
-        <UserInfo />
+        <UserInfo user={data.user} />
       </div>
-      <CardList listTitle="自分の投稿" articles={articles} />
+      <CardList listTitle="自分の投稿" articles={data.articles} />
     </div>
   );
 };

--- a/frontend/snack-review-next/src/component/atoms/Loader.tsx
+++ b/frontend/snack-review-next/src/component/atoms/Loader.tsx
@@ -1,0 +1,7 @@
+export const Loader = () => {
+  return (
+    <div className="flex h-screen items-center justify-center">
+      <div className="h-10 w-10 animate-spin rounded-full border-4 border-red-400 border-t-transparent" />
+    </div>
+  );
+};

--- a/frontend/snack-review-next/src/component/atoms/card/CardSmall.tsx
+++ b/frontend/snack-review-next/src/component/atoms/card/CardSmall.tsx
@@ -1,4 +1,3 @@
-import Image from "next/image";
 import type { ArticleType } from "@/lib/zodSchema";
 import type { FC } from "react";
 import { CardInfo } from "@/component/atoms/card/CardInfo";
@@ -13,7 +12,7 @@ export const CardSmall: FC<Props> = ({ article }) => {
   return (
     <button type="button" className="rounded-xl shadow-md">
       <div key={id} className="flex max-w-full flex-auto">
-        <Image
+        <img
           src={imageUrl || "/no-image-card.png"}
           width={112}
           height={112}

--- a/frontend/snack-review-next/src/component/atoms/card/CategoryTag.tsx
+++ b/frontend/snack-review-next/src/component/atoms/card/CategoryTag.tsx
@@ -12,11 +12,15 @@ export const CategoryTag: FC<Props> = ({ categoryName }) => {
       className={cc([
         "shrink-0 rounded-full py-1 px-1.5 font-bold text-white",
         {
-          "bg-red-400": categoryName === "焼き菓子",
-          "bg-blue-400": categoryName === "ケーキ",
-          "bg-green-400": categoryName === "チョコ",
-          "bg-purple-400": categoryName === "和菓子",
-          "bg-yellow-400": categoryName === "その他",
+          "bg-yellow-400": categoryName === "キャンディ",
+          "bg-amber-800": categoryName === "チョコレート",
+          "bg-amber-400": categoryName === "ビスケット・クッキー",
+          "bg-rose-400": categoryName === "ケーキ",
+          "bg-orange-400": categoryName === "ゼリー・プリン",
+          "bg-blue-400": categoryName === "アイスクリーム・シャーベット",
+          "bg-purple-400": categoryName === "せんべいなど米菓子",
+          "bg-green-400": categoryName === "和菓子",
+          "bg-gray-400": categoryName === "その他",
         },
       ])}
     >

--- a/frontend/snack-review-next/src/component/atoms/card/ConfirmModal.tsx
+++ b/frontend/snack-review-next/src/component/atoms/card/ConfirmModal.tsx
@@ -32,7 +32,10 @@ export const ConfirmModal: FC<Props> = ({ articleState, modalType, isOpen, setIs
     e.preventDefault();
     if (modalType === "post") {
       const findCategory = categories?.find((data) => data.categoryName === articleState.category);
-      axiosClient.post("/articles", { ...articleState, categoryId: Number(findCategory?.id) });
+      const body = { ...articleState, url: shopUrl, categoryId: Number(findCategory?.id) };
+      console.log(body);
+
+      axiosClient.post("/articles", body);
       appearToast("投稿しました");
     } else {
       appearToast("削除しました");

--- a/frontend/snack-review-next/src/component/template/footer/Footer.tsx
+++ b/frontend/snack-review-next/src/component/template/footer/Footer.tsx
@@ -1,12 +1,21 @@
+"use client";
+
+import Cookies from "js-cookie";
 import { FooterLoggedIn } from "./FooterLoggedIn";
 import { FooterNotLoggedIn } from "./FooterNotLoggedIn";
+import { Loader } from "@/component/atoms/Loader";
+import { useUser } from "@/lib/useUser";
 
-export const Footer = (props: { isLoggedIn: boolean; userName: string }) => {
-  const { isLoggedIn, userName } = props;
+export const Footer = () => {
+  const { data } = useUser();
+  const token = Cookies.get("access-token");
+
+  if (!data) return <Loader />;
+
   return (
     <footer className="fixed bottom-0 mt-6 w-full bg-gray-100 py-4 align-middle text-gray-700">
-      <nav className={`${isLoggedIn ? "mx-4" : "mx-3"} flex items-center justify-between`}>
-        {isLoggedIn ? <FooterLoggedIn userName={userName} /> : <FooterNotLoggedIn />}
+      <nav className={`${data ? "mx-4" : "mx-3"} flex items-center justify-between`}>
+        {token ? <FooterLoggedIn userName={data.user.name} /> : <FooterNotLoggedIn />}
       </nav>
     </footer>
   );

--- a/frontend/snack-review-next/src/component/template/home/CardList.tsx
+++ b/frontend/snack-review-next/src/component/template/home/CardList.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Image from "next/image";
 import Link from "next/link";
 import type { ArticlesArrayType } from "@/lib/zodSchema";
 import type { FC } from "react";
@@ -23,7 +22,7 @@ export const CardList: FC<Props> = ({ listTitle, articles }) => {
           return (
             <Link href={articlePath(id.toString())} key={id} className="rounded-xl shadow-md">
               <div key={id} className="flex max-w-full flex-auto">
-                <Image
+                <img
                   src={imageUrl || "/no-image-card.png"}
                   width={112}
                   height={112}

--- a/frontend/snack-review-next/src/component/template/home/Carousel.tsx
+++ b/frontend/snack-review-next/src/component/template/home/Carousel.tsx
@@ -1,4 +1,3 @@
-import Image from "next/image";
 import Link from "next/link";
 import type { ArticlesType } from "@/lib/zodSchema";
 import type { FC } from "react";
@@ -19,8 +18,7 @@ export const Carousel: FC<Props> = ({ popularArticles }) => {
         return (
           <Link href={articlePath(id.toString())} key={article.id} className="carousel-item">
             <div className="relative">
-              <Image
-                priority
+              <img
                 src={imageUrl || "/no-image-carousel.png"}
                 width={320}
                 height={208}

--- a/frontend/snack-review-next/src/component/template/login/LoginComponent.tsx.tsx
+++ b/frontend/snack-review-next/src/component/template/login/LoginComponent.tsx.tsx
@@ -22,9 +22,9 @@ export const LoginComponent = () => {
   });
 
   const onSubmit = handleSubmit(async (data) => {
-    // TODO: ユーザー情報をグローバルステートに入れる
     await login(data);
     router.push("/");
+    router.refresh();
   });
 
   return (

--- a/frontend/snack-review-next/src/component/template/my-profile/MyProfileHeader.tsx
+++ b/frontend/snack-review-next/src/component/template/my-profile/MyProfileHeader.tsx
@@ -11,6 +11,7 @@ export const MyProfileHeader: FC = () => {
   const handleClick = () => {
     logout();
     router.push("/");
+    router.refresh();
   };
 
   return (

--- a/frontend/snack-review-next/src/component/template/my-profile/UserInfo.tsx
+++ b/frontend/snack-review-next/src/component/template/my-profile/UserInfo.tsx
@@ -1,14 +1,16 @@
 import { UserInfoField } from "./UserInfoField";
-import { getUserData } from "@/lib/getData";
+import type { UserType } from "@/lib/zodSchema";
+import type { FC } from "react";
 
-export const UserInfo = async () => {
-  const { user } = await getUserData();
-  const { email, name } = user;
+type Props = {
+  user: UserType;
+};
 
+export const UserInfo: FC<Props> = ({ user }) => {
   return (
     <div className="grid grid-cols-1 gap-6">
-      <UserInfoField label="メールアドレス" value={email} isEditable={false} />
-      <UserInfoField label="ユーザー名" value={name} />
+      <UserInfoField label="メールアドレス" value={user.email} isEditable={false} />
+      <UserInfoField label="ユーザー名" value={user.name} />
       <UserInfoField label="パスワード" />
     </div>
   );

--- a/frontend/snack-review-next/src/lib/authModule.ts
+++ b/frontend/snack-review-next/src/lib/authModule.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { AxiosResponse } from "axios";
 import Cookies from "js-cookie";
 import { UserFormNameType } from "@/constants/InputField";
@@ -41,8 +42,16 @@ export const logout = async () => {
 };
 
 export const getUser = async (input: string) => {
-  const res = await axiosClient.get(input);
-  return res.data;
+  const res = await fetch(input, {
+    method: "GET",
+    headers: {
+      uid: Cookies.get("uid")!,
+      client: Cookies.get("client")!,
+      access_token: Cookies.get("access-token")!,
+    },
+  });
+  const data = await res.json();
+  return data;
 };
 
 export const signup = async (formData: Record<UserFormNameType, string>) => {

--- a/frontend/snack-review-next/src/lib/useUser.ts
+++ b/frontend/snack-review-next/src/lib/useUser.ts
@@ -1,0 +1,15 @@
+import useSWR from "swr";
+import type { MyProfileType } from "./zodSchema";
+import { getUser } from "@/lib/authModule";
+
+export const useUser = () => {
+  const url = "http://localhost:3001/api/v1/my-profile";
+  const { data, error } = useSWR<MyProfileType>(url, getUser);
+
+  const loading = !data && !error;
+
+  return {
+    data,
+    loading,
+  };
+};

--- a/frontend/snack-review-next/src/types/env.d.ts
+++ b/frontend/snack-review-next/src/types/env.d.ts
@@ -1,0 +1,6 @@
+declare namespace NodeJS {
+  interface ProcessEnv {
+    readonly NODE_ENV: "development" | "production" | "test";
+    readonly NEXT_PUBLIC_BASE_URL: string;
+  }
+}


### PR DESCRIPTION
## やったこと
- useSWRでユーザー情報をグローバル管理
- フッターの表示をログイン状態で切り替える

## やらないこと
- 未ログイン時に`/my-profile`と`/article/post`へ遷移できないようにする

## できるようになること（ユーザ目線）
- ログイン後にフッターから`my-profile`へ遷移できる

## その他
- 環境変数を設定しuseSWRで利用したいが変数で渡すと自動的に`http://localhost:3000`が付与されてしまう。そのため現状は直接エンドポイントを入力している。
- 未ログイン時に`/my-profile`と`/article/post`へ遷移できないようにしたい。(時間があれば...)
- 記事投稿後、トップページへ移動したいが`router.push("/")`で遷移するとトーストが消えてしまう。
- 記事のコンテンツ文字量が少ない時、バッジの位置がズレる。
- `/api/v1/my-profile`から取得した`articles`内に`content` が含まれていない。
- シード値から全記事を所得してみたが、見た目が寂しい...
