### PR TITLE
my_profiles、categoriesのRSpecを追記

### DIFF
--- a/backend/snack-review-rails/spec/requests/api/v1/categories_spec.rb
+++ b/backend/snack-review-rails/spec/requests/api/v1/categories_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe "Api::V1::Categories", type: :request do
   describe "GET /index" do
     it "returns http success" do
-      get "/api/v1/categories/index"
+      get "http://localhost:3001/api/v1/categories"
       expect(response).to have_http_status(:success)
     end
   end

--- a/backend/snack-review-rails/spec/requests/api/v1/my_profiles_spec.rb
+++ b/backend/snack-review-rails/spec/requests/api/v1/my_profiles_spec.rb
@@ -1,7 +1,28 @@
 require 'rails_helper'
 
 RSpec.describe "Api::V1::MyProfiles", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
+  let(:user) { create(:user) }
+  let(:category) { create(:category) }
+  let(:article) { create(:article, user: user, category: category) }
+  let(:token) { sign_in user } 
+
+  describe "my-profileのテスト" do
+    context 'ログインしていない時' do
+      it 'showアクション失敗' do
+    
+        get "http://localhost:3001/api/v1/my-profile"
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+    context 'ログインしている時' do
+      it 'showアクション成功' do
+        login_user = create(:user, email: 'test2@example.com')
+        access_token = sign_in(login_user)
+        get "http://localhost:3001/api/v1/my-profile",params: {format: :jbuilder}, headers: access_token
+        expect(response).to have_http_status(:success)
+
+      end
+      
+    end
   end
 end


### PR DESCRIPTION
## やったこと

<!-- このプルリクで何をしたのか？ -->

my_profiles_spec.rbは「get "http://localhost:3001/api/v1/my-profile"」がログインしていないときはレスポンスがNG、
ログインしているときはレスポンスがOKになるテストを追加しました。

categories_spec.rbは「get "http://localhost:3001/api/v1/categories"」のレスポンスがOKになるテストを追加しました。


## やらないこと

<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」で OK）（やらない場合は、いつやるのかを明記する。） -->

-レスポンスがOKかどうかしか確認してないのでJSONのチェックも追加します。

## できるようになること（ユーザ目線）

<!-- 何ができるようになるのか？（あれば。無いなら「無し」で OK）-->

-

## できなくなること（ユーザ目線）

<!-- 何ができるようになるのか？（あれば。無いなら「無し」で OK）-->

-

## 動作確認

<!-- どのような動作確認を行ったのか？　結果はどうか？ -->

bundle exec rspec spec/requests/api/v1/my_profiles_spec.rb
bundle exec rspec spec/requests/api/v1/categories_spec.rb

エラーになったら下記を実行する必要があるかと思います。
bundle install  
rails db:migrate RAILS_ENV=test   

## その他

<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->

-テストパターンが足りていないと思いますので、これもやった方がいいというのがありましたら教えてください。
